### PR TITLE
fix: backfill log start time from duration

### DIFF
--- a/.changes/unreleased/fix-log-start-time.md
+++ b/.changes/unreleased/fix-log-start-time.md
@@ -1,0 +1,3 @@
+kind: fixed
+body: "Default log start times now backfill from the current time based on the logged duration."
+time: 2026-01-06T09:50:52Z

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -218,13 +218,13 @@ func runLog(cmd *cobra.Command, args []string) error {
 	} else if shortcutName == "" && taskKey == "" {
 		// Interactive mode AND not using shortcuts: prompt for start time
 		var err error
-		started, err = ui.PromptStartTime()
+		started, err = ui.PromptStartTime(timeSeconds)
 		if err != nil {
 			return fmt.Errorf("failed to get start time: %w", err)
 		}
 	} else {
-		// Shortcut or CLI mode without --at: use current time
-		started = time.Now()
+		// Shortcut or CLI mode without --at: default to ending now
+		started = time.Now().Add(-time.Duration(timeSeconds) * time.Second)
 	}
 
 	// Confirm before logging

--- a/internal/ui/prompts.go
+++ b/internal/ui/prompts.go
@@ -213,16 +213,16 @@ func Confirm(message string) (bool, error) {
 	return confirmed, nil
 }
 
-// PromptStartTime prompts user for when they worked (optional)
-// Returns time.Now() if user wants current time, otherwise parsed datetime
-func PromptStartTime() (time.Time, error) {
+// PromptStartTime prompts user for when they worked (optional).
+// Returns time.Now() minus the time spent if user wants current time.
+func PromptStartTime(timeSpentSeconds int) (time.Time, error) {
 	useNow, err := Confirm("Log for current time?")
 	if err != nil {
 		return time.Time{}, err
 	}
 
 	if useNow {
-		return time.Now(), nil
+		return time.Now().Add(-time.Duration(timeSpentSeconds) * time.Second), nil
 	}
 
 	var whenStr string


### PR DESCRIPTION
### Motivation

- When logging time without an explicit start (`--at`) the start time defaulted to `time.Now()`, causing entries to end up starting at the log moment rather than ending at that moment and spanning the logged duration.
- Interactive flow that accepts “current time” also returned the literal current time instead of backfilling from the logged duration.
- Add a changelog entry so the fix is tracked for the next release.

### Description

- Change default behavior in `cmd/log.go` so that when `--at` is not provided the start is computed as `time.Now().Add(-time.Duration(timeSeconds) * time.Second)` so entries end at current time and span the logged duration.
- Update interactive prompt signature in `internal/ui/prompts.go` to `PromptStartTime(timeSpentSeconds int)` and make the “Log for current time?” path return `time.Now().Add(-time.Duration(timeSpentSeconds) * time.Second)`.
- Propagate the `timeSeconds` argument to the prompt caller in `cmd/log.go` and add an unreleased `changie` fix entry at `.changes/unreleased/fix-log-start-time.md`.

### Testing

- Ran `make go-test` and unit tests completed successfully (`✓ Tests completed`).
- Ran `make go-lint` which failed due to `golangci-lint` being built with Go 1.24 while the repo `go` version is `1.25.5` (tooling mismatch). 
- Ran `make go-vulncheck` which failed because `govulncheck` is not installed and `go install` was blocked by proxy; this is an environment/tooling issue, not a code failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cda171a3c8332ad81876315413ab9)